### PR TITLE
auto download FidelityFX_CLI and fix ACE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 .vscode
 .directory
+/FidelityFX-CLI.zip
+/FidelityFX-CLI


### PR DESCRIPTION
- Fix Arbitrary code execution vulnerability

you made the same mistake as https://github.com/light-and-ray/sd-webui-topaz-photo-ai-integration in allowing the user to customize the path to the executable though the web interface without any safeguards, and then executing custom path
this leads to an arbitrary code execution

if you wish to allow the user to customize the path to the EXE then either `use command line arg` or you have to add lots of safeguards to prevent malicious changes
adding the safeguards is generally not worth it, so just use `use command line arg`
but since it is possible to Auto download you don't even need to have the user set the path manually
killing two birds with one stone
> the file is only 35 KB is so it's not really wasting that much space even if one already have it installed somewhere else on there PC

> I don't know how to use wine, I wrote this for Windows you might want to add some sort of os check for linux

- Add auto download FidelityFX_CLI

auto download the FidelityFX_CLI release zip file with hash check and extract it to get the FidelityFX_CLI.exe
> yes even though `modelloader.load_file_from_url` is meant for loading models it can totally use download other files

- remove settings

---

please update the readme documentation to reflect the above changes

---

note 
I'm not sure if I done something wrong but the upscale result doesn't seem that good
it's different but doesn't seem to be much better than `Lanczos`