### PR TITLE
linux support + use jpg for temp files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AMD FidelityFX Super Resolution (FSR) 1.0 integration
 
-This extension integrates [AMD FidelityFX Super Resolution (FSR) 1.0](https://gpuopen.com/fidelityfx-superresolution/) upscaling feature into [stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui). AMD FSR1 is based on Lanczos upscale, so don't expect anything amazing. You can use it inside *hires fix*, *upscaler_for_img2img* or in the *extras* tab. Extension will automatically download the FidelityFX_CLI executable during the first run. No manual setup is required.
+This extension integrates [AMD FidelityFX Super Resolution (FSR) 1.0](https://gpuopen.com/fidelityfx-superresolution/) upscaling feature into [stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui). AMD FSR1 is based on Lanczos upscale, so don't expect anything amazing. You can use it inside *hires fix*, *upscaler_for_img2img* or in the *extras* tab. Extension will automatically download the FidelityFX_CLI executable during the first run. No manual setup is required. For linux you need to have `wine` in `PATH`
 
 ![](/images/preview.png)
 ![](/images/upscalers.png)

--- a/scripts/fidelityfx_tools.py
+++ b/scripts/fidelityfx_tools.py
@@ -28,6 +28,8 @@ def getFidelityFXEXE():
 def runFidelityFX_(scale, input_file, output_file):
     exe = getFidelityFXEXE()
     cmd = [exe, '-Scale', f'{scale}x', f'{scale}x', '-Mode', 'CAS', '-Sharpness', '1.0', input_file, output_file]
+    if os.name != 'nt':
+        cmd = ['wine'] + cmd
     print(' '.join(cmd))
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
@@ -38,9 +40,9 @@ def runFidelityFX(img: Image.Image, scale: int) -> Image.Image:
     tmpInDir = TemporaryDirectory()
     tmpOutDir = TemporaryDirectory()
     try:
-        fileIn = os.path.join(tmpInDir.name, 'file.png')
-        fileOut = os.path.join(tmpOutDir.name, 'file.png')
-        img.convert('RGB').save(fileIn, 'PNG')
+        fileIn = os.path.join(tmpInDir.name, 'file.jpg')
+        fileOut = os.path.join(tmpOutDir.name, 'file.jpg')
+        img.convert('RGB').save(fileIn, quality=100)
         runFidelityFX_(scale, fileIn, fileOut)
         if not os.path.exists(fileOut):
             raise Exception("FidelityFX didn't process any image")


### PR DESCRIPTION
Automatically add 'wine' in command for linux. Plus it took extremely much time for me. I watched in code, and saw you changed extension of temp files to png. Png is extremely slow especially for big images. And there are 2 times of saving. Jpeg 100% has no visible difference